### PR TITLE
Simplify check connect function

### DIFF
--- a/previs/core.py
+++ b/previs/core.py
@@ -42,7 +42,7 @@ from astroquery.vizier import Vizier
 from previs.instr import (chara_limit, gravity_limit, matisse_limit,
                           pionier_limit)
 from previs.sed import getSed, sed2mag
-from previs.utils import printtime, check_response_server
+from previs.utils import printtime, check_servers_response
 from termcolor import cprint
 from uncertainties import ufloat
 
@@ -81,9 +81,7 @@ def search(star, source='ESO', check=False, verbose=True):
         -'Guiding_star': Guiding star informations at VLTI.\n
     """
 
-    if check_response_server() is not None:
-        pass
-    else:
+    if check_servers_response() is None:
         return None
 
     start_time = time.time()
@@ -295,9 +293,7 @@ def survey(list_star):
     `survey`: {dict}
         Dictionnary containing previs search for all stars.
     """
-    if check_response_server() is not None:
-        pass
-    else:
+    if check_servers_response() is None:
         return None
    
     cprint('\nStarting survey on %i stars:' % len(list_star), 'cyan')

--- a/previs/utils.py
+++ b/previs/utils.py
@@ -33,7 +33,7 @@ def connect(host):
         return False
 
 
-def check_response_server():
+def check_servers_response():
     connect_simbad = connect('http://simbad.u-strasbg.fr/simbad')
     connect_vizier = connect('http://vizier.u-strasbg.fr/vizier/sed/')
     if connect_simbad and connect_vizier:


### PR DESCRIPTION
Simplify internal logic, and only log the most relevant source of error when connection fails, instead of logging all three every time something goes wrong.